### PR TITLE
feat: enable real time validation of slug on company creation page

### DIFF
--- a/src/components/molecules/FormErrorHelper/FormErrorHelper.tsx
+++ b/src/components/molecules/FormErrorHelper/FormErrorHelper.tsx
@@ -4,6 +4,7 @@ import { FieldError } from 'react-hook-form';
 const errorMessages = {
   validate: 'The pattern does not match the required format.',
   required: 'This field is required.',
+  notUnique: 'This URL is not unique.',
 };
 
 type FormErrorHelperProps = {

--- a/src/lib/debounce.js
+++ b/src/lib/debounce.js
@@ -1,0 +1,11 @@
+const debounce = (func, timeout = 300) => {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      func.apply(this, args);
+    }, timeout);
+  };
+};
+
+export default debounce;

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,6 @@
+import slugify from 'slugify';
+
+export const toSlug = (str: string): string =>
+  slugify(str || '', { lower: true, strict: true });
+
+export const validateSlug = (str: string): boolean => str === toSlug(str);

--- a/src/pages/api/unique-slug.ts
+++ b/src/pages/api/unique-slug.ts
@@ -1,0 +1,39 @@
+import prisma from '@/lib/prisma';
+import { validateSlug } from '@/lib/slug';
+import { NextApiHandler } from 'next';
+import { getSession } from 'next-auth/client';
+
+const handle: NextApiHandler = async (req, res) => {
+  const { slug } = req.body;
+
+  if (!validateSlug(slug)) {
+    res.json({
+      error: 'Slug format is not valid.',
+    });
+    return;
+  }
+
+  const session = await getSession({ req });
+  if (!session) {
+    res.json({
+      error: 'You are not logged in.',
+    });
+    return;
+  }
+
+  const isUnique = !(await prisma.company.findUnique({
+    where: { slug },
+    select: { slug: true },
+  }));
+
+  if (!isUnique) {
+    res.json({
+      isUnique: false,
+      error: `A company with the slug “${slug}” already exists.`,
+    });
+    return;
+  }
+  return res.status(200).json({ isUnique: true });
+};
+
+export default handle;


### PR DESCRIPTION
# Overview

Enabled validation of slugs in real time during company creation.

## What we have done

- Created new api route `/api/unique-slug` that responds whether a `slug` sent in the payload is unique or not
- Created debounce utility function under `/lib`
- Created `onBlur` event to detect whether slug is unique during creation

## How to test

- Type in a slug at `/create-company` and click outside the component;
- If it exists, a red message should appear stating it is not unique;

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
