### PR TITLE
feat: charge and subscription status via stripe

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@emotion/styled": "^11",
     "@prisma/client": "^2.29.0",
     "axios": "^0.21.4",
+    "date-fns": "^2.23.0",
     "focus-visible": "^5.2.0",
     "framer-motion": "^4",
     "next": "^11.1.2",

--- a/prisma/migrations/20210909202648_add_subscription_id/migration.sql
+++ b/prisma/migrations/20210909202648_add_subscription_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Company" ADD COLUMN     "subscriptionId" TEXT;

--- a/prisma/migrations/20210909215441_create_session_id/migration.sql
+++ b/prisma/migrations/20210909215441_create_session_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Company" ADD COLUMN     "sessionId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,8 @@ model Company {
   title     String
   domain    String?
   priceId   String
+  subscriptionId  String?
+  sessionId  String?
   admin     User?   @relation(fields: [adminId], references: [id])
   adminId   Int
   signatures  Signature[]

--- a/src/components/molecules/SignatureCard/SignatureCard.tsx
+++ b/src/components/molecules/SignatureCard/SignatureCard.tsx
@@ -1,5 +1,5 @@
 import Card from '@/components/atoms/Card';
-import { SignatureResponse } from '@/pages/api/company/signatures';
+import { SignatureResponse } from '@/pages/api/company/[slug]/signatures';
 import { Heading, Text } from '@chakra-ui/react';
 import Link from 'next/link';
 

--- a/src/components/molecules/SubscriptionStatus/SubscriptionStatus.tsx
+++ b/src/components/molecules/SubscriptionStatus/SubscriptionStatus.tsx
@@ -1,0 +1,128 @@
+import { Button } from '@chakra-ui/button';
+import axios from 'axios';
+import useSWR from 'swr';
+import Link from 'next/link';
+import {
+  Text,
+  Badge,
+  VStack,
+  Box,
+  ComponentWithAs,
+  StackProps,
+  Skeleton,
+} from '@chakra-ui/react';
+import { format, fromUnixTime } from 'date-fns';
+import { SubscriptionResponse } from '@/pages/api/company/[slug]/subscription';
+import Stripe from 'stripe';
+
+type SubscriptionStatusProps = {
+  companySlug: string;
+};
+
+const fetcher = async (url: string) =>
+  await axios.get<SubscriptionResponse>(url);
+
+const SubscriptionStatus: ComponentWithAs<
+  'div',
+  StackProps & SubscriptionStatusProps
+> = ({ companySlug, ...props }) => {
+  const {
+    data: response,
+    error,
+    revalidate,
+  } = useSWR(`/api/company/${companySlug}/subscription`, fetcher, {
+    revalidateOnFocus: false,
+  });
+  const subscription = response?.data;
+
+  if (!response && !error) {
+    return (
+      <VStack {...props}>
+        <Skeleton h="1rem">Status: Loading</Skeleton>
+        <Skeleton h=".6rem"></Skeleton>
+      </VStack>
+    );
+  }
+
+  if (error || (subscription && 'error' in subscription))
+    return (
+      <VStack {...props}>
+        <Box>Failed to load plan status :(</Box>
+        <Button onClick={revalidate} variant="secondary" size="sm">
+          Reload
+        </Button>
+      </VStack>
+    );
+
+  return (
+    <VStack {...props}>
+      <StatusBox
+        isFree={subscription?.isFree}
+        status={subscription?.status}
+        renewOn={subscription?.current_period_end}
+        payUrl={subscription?.payUrl}
+      />
+    </VStack>
+  );
+};
+
+type StatusBoxProps = {
+  isFree?: boolean;
+  status?: Stripe.Subscription.Status;
+  renewOn?: number;
+  payUrl?: string;
+};
+const StatusBox: React.VFC<StatusBoxProps> = ({
+  isFree,
+  status,
+  renewOn,
+  payUrl,
+}) => {
+  const getBadgeColourScheme = (status?: Stripe.Subscription.Status) => {
+    switch (status) {
+      case 'active':
+        return 'green';
+      default:
+        return 'red';
+    }
+  };
+
+  if (isFree || !status)
+    return (
+      <Box>
+        <Badge colorScheme="blackAlpha">Free plan</Badge>
+        <Text fontSize="xs" color="gray.500">
+          Offers limited functionality. Upgrade to unlock templates and
+          features.
+        </Text>
+      </Box>
+    );
+
+  return (
+    <Box>
+      Subscription:{' '}
+      <Badge colorScheme={getBadgeColourScheme(status)}>{status}</Badge>
+      {status === 'unpaid' && (
+        <>
+          <Text fontSize="xs" color="gray.500">
+            Features are locked until you update your subscription.
+          </Text>
+          {payUrl && (
+            <Link href={payUrl} passHref>
+              <Button colorScheme="green" variant="ghost" size="sm">
+                Pay via Stripe
+              </Button>
+            </Link>
+          )}
+        </>
+      )}
+      {status === 'active' && renewOn && (
+        <Text fontSize="xs" color="gray.500">
+          renew: {format(fromUnixTime(renewOn), 'P')}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+export default SubscriptionStatus;

--- a/src/components/organisms/PageHeader/PageHeader.tsx
+++ b/src/components/organisms/PageHeader/PageHeader.tsx
@@ -1,19 +1,30 @@
 import Breadcrumbs, {
   Breadcrumb,
 } from '@/components/molecules/Breadcrumbs/Breadcrumbs';
-import { Box, Container, Heading } from '@chakra-ui/react';
+import { Box, Container, Heading, Stack } from '@chakra-ui/react';
+import { ReactNode } from 'react';
 
 type PageHeaderProps = {
   title: string;
   breadcrumbs?: Breadcrumb[];
+  tools?: ReactNode;
 };
 
-const PageHeader: React.VFC<PageHeaderProps> = ({ title, breadcrumbs }) => {
+const PageHeader: React.VFC<PageHeaderProps> = ({
+  title,
+  breadcrumbs,
+  tools,
+}) => {
   return (
     <Box>
       <Container maxW="container.lg" py={8}>
         {breadcrumbs && <Breadcrumbs items={breadcrumbs} />}
-        <Heading as="h1">{title}</Heading>
+        <Stack direction={{ base: 'column', md: 'row' }} spacing={8}>
+          <Heading as="h1" flexGrow={1}>
+            {title}
+          </Heading>
+          {tools}
+        </Stack>
       </Container>
     </Box>
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,1 @@
+export type ErrorMessage = { error: string };

--- a/src/pages/api/company/[slug]/delete.ts
+++ b/src/pages/api/company/[slug]/delete.ts
@@ -1,9 +1,18 @@
 import { NextApiHandler } from 'next';
 import { getSession } from 'next-auth/client';
 import prisma from '@/lib/prisma';
+import stripe from '@/lib/stripe';
 
 const handle: NextApiHandler = async (req, res) => {
-  const { slug } = req.body;
+  const { slug } = req.query;
+
+  // If company slug is not a string, return Bad Request
+  if (typeof slug !== 'string') {
+    res.status(400).json({
+      error: `Invalid company: ${slug}`,
+    });
+    return;
+  }
 
   const session = await getSession({ req });
   if (!session) {
@@ -16,12 +25,17 @@ const handle: NextApiHandler = async (req, res) => {
     .findUnique({ where: { id: session?.id } })
     .companies();
 
-  if (!userCompanies.find((company) => company.slug === slug)) {
+  const company = userCompanies.find((company) => company.slug === slug);
+
+  if (!company) {
     res.status(401).json({
       message: 'Unauthorized',
     });
     return;
   }
+
+  if (company.subscriptionId)
+    await stripe.subscriptions.del(company.subscriptionId);
 
   await prisma.signature.deleteMany({
     where: { companySlug: slug },

--- a/src/pages/api/company/[slug]/subscription.ts
+++ b/src/pages/api/company/[slug]/subscription.ts
@@ -1,0 +1,92 @@
+import prisma from '@/lib/prisma';
+import stripe from '@/lib/stripe';
+import { ErrorMessage } from '@/lib/types';
+import { NextApiHandler } from 'next';
+import { getSession } from 'next-auth/client';
+import Stripe from 'stripe';
+
+type Subscription = {
+  isFree: boolean;
+  status: Stripe.Subscription.Status;
+  current_period_end?: number;
+  payUrl?: string;
+};
+
+export type SubscriptionResponse = Subscription | ErrorMessage;
+
+const handle: NextApiHandler = async (req, res) => {
+  const { slug } = req.query;
+
+  // If company slug is not a string, return Bad Request
+  if (typeof slug !== 'string') {
+    res.status(400).json({
+      error: `Invalid company: ${slug}`,
+    });
+    return;
+  }
+
+  const session = await getSession({ req });
+  // If the user is not logged in, return Unauthorized
+  if (!session?.id) {
+    res.status(401).json({
+      error: 'User not logged in',
+    });
+    return;
+  }
+
+  const userCompanies = await prisma.user.findUnique({
+    where: { id: session.id },
+    select: {
+      companies: {
+        where: { slug: slug },
+        select: { sessionId: true, subscriptionId: true, priceId: true },
+      },
+    },
+  });
+
+  if (!userCompanies) {
+    res.status(401).json({
+      error: 'User not part of the company',
+    });
+    return;
+  }
+
+  const {
+    subscriptionId: companySubscriptionId,
+    sessionId,
+    priceId,
+  } = userCompanies.companies[0];
+
+  const price =
+    (await (await stripe.prices.retrieve(priceId)).unit_amount) || 0;
+
+  let subscriptionId = companySubscriptionId;
+  let stripeSession;
+  let stripeSubscription;
+
+  if (sessionId && !subscriptionId) {
+    stripeSession = await stripe.checkout.sessions.retrieve(sessionId);
+    if (typeof stripeSession.subscription === 'string') {
+      await prisma.company.update({
+        where: { slug: slug },
+        data: { subscriptionId: stripeSession.subscription },
+      });
+      subscriptionId = stripeSession.subscription;
+    }
+  }
+
+  if (subscriptionId) {
+    stripeSubscription = await stripe.subscriptions.retrieve(subscriptionId);
+  }
+
+  const response = {
+    isFree: price <= 0,
+    status: stripeSubscription?.status || 'unpaid',
+    current_period_end: stripeSubscription?.current_period_end,
+    payUrl: stripeSession?.url || undefined,
+  };
+
+  return res.status(200).json(response);
+};
+
+export default handle;

--- a/src/pages/api/company/create.ts
+++ b/src/pages/api/company/create.ts
@@ -1,6 +1,7 @@
 import { NextApiHandler } from 'next';
 import { getSession } from 'next-auth/client';
 import prisma from '@/lib/prisma';
+import stripe from '@/lib/stripe';
 
 const handle: NextApiHandler = async (req, res) => {
   const { title, domain, slug, priceId } = req.body;
@@ -24,16 +25,25 @@ const handle: NextApiHandler = async (req, res) => {
     return;
   }
 
+  const stripeSession = await stripe.checkout.sessions.create({
+    success_url: `http://localhost:3000/company/${slug}`,
+    cancel_url: `http://localhost:3000/company/${slug}`,
+    payment_method_types: ['card'],
+    line_items: [{ price: priceId, quantity: 1 }],
+    mode: 'subscription',
+  });
+
   const result = await prisma.company.create({
     data: {
       title,
       domain,
       slug,
       priceId,
+      sessionId: stripeSession.id,
       admin: { connect: { id: session?.id } },
     },
   });
-  res.json(result);
+  res.json({ ...result, redirectURL: stripeSession.url });
 };
 
 export default handle;

--- a/src/pages/api/company/create.ts
+++ b/src/pages/api/company/create.ts
@@ -6,6 +6,8 @@ import stripe from '@/lib/stripe';
 const handle: NextApiHandler = async (req, res) => {
   const { title, domain, slug, priceId } = req.body;
 
+  const host = req.headers.host || 'localhost:3000';
+
   const session = await getSession({ req });
   if (!session) {
     res.json({
@@ -26,8 +28,8 @@ const handle: NextApiHandler = async (req, res) => {
   }
 
   const stripeSession = await stripe.checkout.sessions.create({
-    success_url: `http://localhost:3000/company/${slug}`,
-    cancel_url: `http://localhost:3000/company/${slug}`,
+    success_url: `http://${host}/company/${slug}`,
+    cancel_url: `http://${host}/company/${slug}`,
     payment_method_types: ['card'],
     line_items: [{ price: priceId, quantity: 1 }],
     mode: 'subscription',

--- a/src/pages/company/[slug].tsx
+++ b/src/pages/company/[slug].tsx
@@ -1,5 +1,7 @@
+import ActionSheet from '@/components/molecules/ActionSheet/ActionSheet';
 import DeleteButton from '@/components/molecules/DeleteButton/DeleteButton';
 import SignatureCard from '@/components/molecules/SignatureCard';
+import SubscriptionStatus from '@/components/molecules/SubscriptionStatus/SubscriptionStatus';
 import PageHeader from '@/components/organisms/PageHeader';
 import UnauthorisedMessage from '@/components/organisms/UnauthorisedMessage';
 import prisma from '@/lib/prisma';
@@ -23,7 +25,7 @@ import { useRouter } from 'next/dist/client/router';
 import Link from 'next/link';
 import { useState } from 'react';
 import useSWR from 'swr';
-import { SignaturesQueryResponse } from '../api/company/signatures';
+import { SignaturesQueryResponse } from '../api/company/[slug]/signatures';
 
 type CompanyDetailsProps = {
   company: Company;
@@ -35,7 +37,7 @@ const CompanyDetailsRoute: React.VFC<CompanyDetailsProps> = ({ company }) => {
   const { push } = useRouter();
   const [isLoadingDelete, setIsLoadingDelete] = useState(false);
   const { data: signatures } = useSWR<SignaturesQueryResponse>(
-    `/api/company/signatures?companySlug=${company?.slug}`,
+    `/api/company/${company?.slug}/signatures`,
     fetcher
   );
 
@@ -44,9 +46,7 @@ const CompanyDetailsRoute: React.VFC<CompanyDetailsProps> = ({ company }) => {
   const handleDelete = async () => {
     setIsLoadingDelete(true);
     try {
-      const request = await axios.post(`/api/company/delete`, {
-        slug: company.slug,
-      });
+      const request = await axios.post(`/api/company/${company.slug}/delete`);
       if (request.status === 200) {
         push('/companies');
       }
@@ -61,6 +61,13 @@ const CompanyDetailsRoute: React.VFC<CompanyDetailsProps> = ({ company }) => {
       <PageHeader
         title={company.title}
         breadcrumbs={[{ label: 'Companies', href: '/companies' }]}
+        tools={
+          <SubscriptionStatus
+            align="initial"
+            w={{ md: '200px' }}
+            companySlug={company.slug}
+          />
+        }
       />
 
       <Container maxW="container.lg">
@@ -92,7 +99,7 @@ const CompanyDetailsRoute: React.VFC<CompanyDetailsProps> = ({ company }) => {
               </SimpleGrid>
             </TabPanel>
 
-            <TabPanel px={{ md: 0 }} py={4}>
+            <TabPanel p={4} as={ActionSheet} mt={4}>
               <Heading as="h3" size="md" mb={4}>
                 Change information
               </Heading>

--- a/src/pages/create-company.tsx
+++ b/src/pages/create-company.tsx
@@ -83,7 +83,7 @@ const CreateCompanyRoute: React.VFC = () => {
     try {
       const response = await axios.post('/api/company/create', data);
       if (!response.data.error) {
-        push(`/company/${response.data.slug}`);
+        push(response.data.redirectURL);
       } else {
         toast({
           title: 'Oops',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,6 +2676,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
+
 debug@2, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
# Overview

implemented charging for subscriptions and status.

## What we have done

- Refactor on company API routes
- Added API route for subscription
- Added two new columns to Company table: sessionId and subscriptionId
- Redirections to stripe and back when paying

## Blockers/Issues

- Still charging for £0 plans.

## How to test

- Create a new company

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added all necessary code documentation and specifications
- [x] I have performed manual tests to ensure the system is working as expected
- [ ] I have created automated tests to replicate my manual testing automatically
